### PR TITLE
Fill problematic values when creating the skycoord objects

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -141,8 +141,8 @@ Finally, we can retrieve a `~astropy.coordinates.SkyCoord` object for all rows::
          (322.13767285, 50.36279294, 3413.80786286),
          (322.10360875, 50.62762822, 1591.7854934 )]
      (pm_ra_cosdec, pm_dec, radial_velocity) in (mas / yr, mas / yr, km / s)
-        [(-4.24880717, -4.52180435, 0.), ( 1.90317677, -3.80754094, 0.),
-         (-2.89919833, -3.87763849, 0.), (-4.62431593, -2.00130269, 0.)]>
+        [(-4.24880717, -4.52180435, nan), ( 1.90317677, -3.80754094, nan),
+         (-2.89919833, -3.87763849, nan), (-4.62431593, -2.00130269, nan)]>
 
 But note that this computes the distance using 1/parallax.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -141,8 +141,8 @@ Finally, we can retrieve a `~astropy.coordinates.SkyCoord` object for all rows::
          (322.13767285, 50.36279294, 3413.80786286),
          (322.10360875, 50.62762822, 1591.7854934 )]
      (pm_ra_cosdec, pm_dec, radial_velocity) in (mas / yr, mas / yr, km / s)
-        [(-4.24880717, -4.52180435, nan), ( 1.90317677, -3.80754094, nan),
-         (-2.89919833, -3.87763849, nan), (-4.62431593, -2.00130269, nan)]>
+        [(-4.24880717, -4.52180435, 0.), ( 1.90317677, -3.80754094, 0.),
+         (-2.89919833, -3.87763849, 0.), (-4.62431593, -2.00130269, 0.)]>
 
 But note that this computes the distance using 1/parallax.
 

--- a/pyia/data.py
+++ b/pyia/data.py
@@ -440,6 +440,10 @@ class GaiaData:
         """
         Return an `~astropy.coordinates.SkyCoord` object to represent
         all coordinates. Note: this requires Astropy v3.0 or higher!
+        
+        `ref_epoch` is used to set the `obstime` attribute on the coordinate
+        objects.  This is often included in the DR2 tables, but `ref_epoch`
+        here is used if it's not. 
         """        
         _coord_opts = (distance, radial_velocity)
         if 'coord' in self._cache:

--- a/pyia/data.py
+++ b/pyia/data.py
@@ -228,7 +228,7 @@ class GaiaData:
         return np.vstack((self.pmra.value, self.pmdec.to(_u).value)).T * _u
     
     @u.quantity_input(min_parallax=u.mas, equivalencies=u.parallax())
-    def get_distance(self, min_parallax=None, allow_negative=True):
+    def get_distance(self, min_parallax=None, allow_negative=False):
         """
         Compute distance from parallax using `~astropy.coordinates.Distance`.
         

--- a/pyia/data.py
+++ b/pyia/data.py
@@ -227,16 +227,25 @@ class GaiaData:
         _u = self.pmra.unit
         return np.vstack((self.pmra.value, self.pmdec.to(_u).value)).T * _u
     
-    @u.quantity_input(clip_value=u.mas, equivalencies=u.parallax())
-    def get_distance(self, clip_value=None):
+    @u.quantity_input(min_parallax=u.mas, equivalencies=u.parallax())
+    def get_distance(self, min_parallax=None, allow_negative=True):
+        """
+        Compute distance from parallax using `~astropy.coordinates.Distance`.
+        
+        If `min_parallax` supplied, then the parallaxes are clipped to this
+        values (and it is also used to replace NaNs).
+        
+        `allow_negative` is passed through to `~astropy.coordinates.Distance`.
+        """
+        
         plx = self.parallax.copy()
 
-        if clip_value is not None:
-            clipped = plx < clip_value.to(plx.unit, u.parallax())
+        if min_parallax is not None:
+            clipped = plx < min_parallax.to(plx.unit, u.parallax())
             clipped |= ~np.isfinite(plx)
-            plx[clipped] = clip_value.to(plx.unit, u.parallax())
+            plx[clipped] = min_parallax.to(plx.unit, u.parallax())
 
-        return coord.Distance(parallax=plx, allow_negative=True)                  
+        return coord.Distance(parallax=plx, allow_negative=allow_negative)                  
 
     @property
     def distance(self):


### PR DESCRIPTION
This PR fixes a few problematic values that can affect generating a robust `skycoord` property:

1. Enforce minimum parallax of 1 micro-arcsec when computing the `distance` property
2. Fill NaN `radial_velocity` values with zeros
3. Set the `obstime` property based on the `ref_epoch` column in the GAIA ctalogs.  

With these fixes, the `~astropy.coordinates.SkyCoord.apply_space_motion` method should work for propagating the GAIA proper motions to a given observation epoch.