### PR TITLE
Quiet the astroquery output

### DIFF
--- a/pyia/data.py
+++ b/pyia/data.py
@@ -136,7 +136,7 @@ class GaiaData:
         self._cache = dict()
 
     @classmethod
-    def from_query(cls, query_str, login_info=None):
+    def from_query(cls, query_str, login_info=None, verbose=False):
         """
         Run the specified query and return a `GaiaData` instance with the
         returned data.
@@ -173,7 +173,7 @@ class GaiaData:
         if login_info is not None:
             Gaia.login(**login_info)
 
-        job = Gaia.launch_job_async(query_str)
+        job = Gaia.launch_job_async(query_str, verbose=verbose)
         tbl = job.get_results()
 
         return cls(tbl)


### PR DESCRIPTION
According to [this](https://github.com/astropy/astroquery/blob/16a01bcbfdf0aca3e6dae78e588b256b737bc7ea/astroquery/gaia/core.py#L853) astroquery line, `launch_job_async` has a `verbose` argument to silence the output of the `astroquery` search for Gaia. Since this makes `pyia` a little noisy, I propose `pyia` uses this keyword, and set it to `False` by default. 



